### PR TITLE
Fix broken links

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,13 +63,13 @@
     "arduino-lib-json": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-E91cW5S12zp1xnrSB2UjmeS3qXe3NRm19LFfqQRVqOk=",
+        "narHash": "sha256-ilnbaqNHtv8/aCHrKYcC/GT4xMsvaLpglZ5T0JaEM+Y=",
         "type": "file",
-        "url": "http://downloads.arduino.cc/libraries/library_index.json"
+        "url": "https://downloads.arduino.cc/libraries/library_index.json"
       },
       "original": {
         "type": "file",
-        "url": "http://downloads.arduino.cc/libraries/library_index.json"
+        "url": "https://downloads.arduino.cc/libraries/library_index.json"
       }
     },
     "arduino-monitor-serial": {
@@ -89,11 +89,11 @@
       "locked": {
         "narHash": "sha256-6zJLWaDLHTaJ14QYVZKjoX7sB/kuGwAWUrrsnBK1xL0=",
         "type": "file",
-        "url": "http://downloads.arduino.cc/packages/package_index.json"
+        "url": "https://downloads.arduino.cc/packages/package_index.json"
       },
       "original": {
         "type": "file",
-        "url": "http://downloads.arduino.cc/packages/package_index.json"
+        "url": "https://downloads.arduino.cc/packages/package_index.json"
       }
     },
     "arduino-tools-avr-gcc": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,11 +9,11 @@
         keymaps-model100   = { url = "github:shajra/empty"; flake = false; };
         keymaps-moonlander = { url = "github:shajra/empty"; flake = false; };
         arduino-lib-json = {
-            url = "file+http://downloads.arduino.cc/libraries/library_index.json";
+            url = "file+https://downloads.arduino.cc/libraries/library_index.json";
             flake = false;
         };
         arduino-pkgs-json = {
-            url = "file+http://downloads.arduino.cc/packages/package_index.json";
+            url = "file+https://downloads.arduino.cc/packages/package_index.json";
             flake = false;
         };
         arduino-boardsmanager-empty = {


### PR DESCRIPTION
Tried this locally, and the old http://** gave 301, as you can see with
```
curl http://downloads.arduino.cc/libraries/library_index.json -v
...
< HTTP/1.1 301 Moved Permanently
...
```
After these updates it worked for me.

Great project btw, used it for many years, but tried the newest revision today.