### PR TITLE
Fix Keyboardio udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,20 +92,20 @@ The following are recommended rules for each keyboard:
     
     # For Model 100
     SUBSYSTEMS=="usb", ATTRS{idVendor}=="3496", ATTRS{idProduct}=="0005", \
-        SYMLINK+="model100", ENV{ID_MM_DEVICE_IGNORE}:="1", \
-        ENV{ID_MM_CANDIDATE}:="0", MODE="0666", TAG+="uaccess", TAG+="seat"
+        SYMLINK+="model100", ENV{ID_MM_DEVICE_IGNORE}="1", \
+        ENV{ID_MM_CANDIDATE}="0", MODE="0666", TAG+="uaccess", TAG+="seat"
     
     SUBSYSTEMS=="usb", ATTRS{idVendor}=="3496", ATTRS{idProduct}=="0006", \
-        SYMLINK+="model100", ENV{ID_MM_DEVICE_IGNORE}:="1", \
-        ENV{ID_MM_CANDIDATE}:="0", MODE="0666", TAG+="uaccess", TAG+="seat"
+        SYMLINK+="model100", ENV{ID_MM_DEVICE_IGNORE}="1", \
+        ENV{ID_MM_CANDIDATE}="0", MODE="0666", TAG+="uaccess", TAG+="seat"
     
     # For Model 01
     SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2300", \
-        SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}:="1",   \
-        ENV{ID_MM_CANDIDATE}:="0", MODE="0666", TAG+="uaccess", TAG+="seat"
+        SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}="1",   \
+        ENV{ID_MM_CANDIDATE}="0", MODE="0666", TAG+="uaccess", TAG+="seat"
     SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2301", \
-        SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}:="1",   \
-        ENV{ID_MM_CANDIDATE}:="0", MODE="0666", TAG+="uaccess", TAG+="seat"
+        SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}="1",   \
+        ENV{ID_MM_CANDIDATE}="0", MODE="0666", TAG+="uaccess", TAG+="seat"
 
 These settings should roughly correspond to the official documentation of tools and libraries used by this project:
 

--- a/README.org
+++ b/README.org
@@ -99,20 +99,20 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", \
 
 # For Model 100
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="3496", ATTRS{idProduct}=="0005", \
-    SYMLINK+="model100", ENV{ID_MM_DEVICE_IGNORE}:="1", \
-    ENV{ID_MM_CANDIDATE}:="0", MODE="0666", TAG+="uaccess", TAG+="seat"
+    SYMLINK+="model100", ENV{ID_MM_DEVICE_IGNORE}="1", \
+    ENV{ID_MM_CANDIDATE}="0", MODE="0666", TAG+="uaccess", TAG+="seat"
 
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="3496", ATTRS{idProduct}=="0006", \
-    SYMLINK+="model100", ENV{ID_MM_DEVICE_IGNORE}:="1", \
-    ENV{ID_MM_CANDIDATE}:="0", MODE="0666", TAG+="uaccess", TAG+="seat"
+    SYMLINK+="model100", ENV{ID_MM_DEVICE_IGNORE}="1", \
+    ENV{ID_MM_CANDIDATE}="0", MODE="0666", TAG+="uaccess", TAG+="seat"
 
 # For Model 01
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2300", \
-    SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}:="1",   \
-    ENV{ID_MM_CANDIDATE}:="0", MODE="0666", TAG+="uaccess", TAG+="seat"
+    SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}="1",   \
+    ENV{ID_MM_CANDIDATE}="0", MODE="0666", TAG+="uaccess", TAG+="seat"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2301", \
-    SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}:="1",   \
-    ENV{ID_MM_CANDIDATE}:="0", MODE="0666", TAG+="uaccess", TAG+="seat"
+    SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}="1",   \
+    ENV{ID_MM_CANDIDATE}="0", MODE="0666", TAG+="uaccess", TAG+="seat"
 #+end_example
 
 These settings should roughly correspond to the official documentation of tools


### PR DESCRIPTION
It raised warnings about `:=` saying that doesn't exist and it was assuming `=`. So it worked, but was not fully valid.