### PR TITLE
Ensure git is available during flash process

### DIFF
--- a/nix/flash.nix
+++ b/nix/flash.nix
@@ -3,6 +3,7 @@
   gnused,
   gnutar,
   gzip,
+  git,
   lib,
   nix-project-lib,
   shajra-keyboards-keymaps,
@@ -45,6 +46,7 @@ nix-project-lib.writeShellCheckedExe name
       gnused
       gnutar
       gzip
+      git
     ];
   }
   ''


### PR DESCRIPTION
This avoids an error complaining that git doesn't exist during build/flash.

This fixes #2.